### PR TITLE
Fix logic around property's readonly & construct-only

### DIFF
--- a/src/gir-module.ts
+++ b/src/gir-module.ts
@@ -995,11 +995,11 @@ export class GirModule {
         construct = false,
         optional = true,
     ): TsProperty | undefined {
-        if (girBool((girProp as GirPropertyElement).$['construct-only']) && !construct) return undefined
         if (!girBool(girProp.$.writable) && construct) return undefined
         if (girBool((girProp as GirFieldElement).$.private)) return undefined
 
-        const readonly = girBool(girProp.$.writable)
+        const readonly =
+            !girBool(girProp.$.writable) || (!construct && girBool((girProp as GirPropertyElement).$['construct-only']))
         girProp._girType = girType
 
         let tsData: TsProperty | TsVar | undefined

--- a/src/type-definition-generator.ts
+++ b/src/type-definition-generator.ts
@@ -94,7 +94,7 @@ export default class TypeDefinitionGenerator implements Generator {
 
         const indent = generateIndent(indentCount)
         const varDesc = this.generateVariable(girProp, namespace, 0)
-        const prefix = (girProp as GirPropertyElement)._tsData?.readonly ? '' : 'readonly '
+        const prefix = (girProp as GirPropertyElement)._tsData?.readonly ? 'readonly ' : ''
 
         return `${indent}${prefix}${varDesc}`
     }


### PR DESCRIPTION
First, fix a reversal of logic: output a "readonly" property when the
property _is_ readonly, and mark a property as readonly when a property
_is not_ writable.

Then, handle the construct-only property correctly: when a property is
construct-only, the property shouldn't vanish when not in construct
prop. Instead, the property should appear as a readonly.

The first case should fix GstObject's 'name' property appears as
'readonly' in subclasses (it isn't), while the second case should fix
GstPad's 'direction' property missing.

-----------------------------------------------------

This is an example of changes which my commit intended to make (only the first 2 hunks):

```patch
diff --git a/@types/node-gtk/Gst-1.0.d.ts b/@types/node-gtk/Gst-1.0.d.ts
index 0ac0d9d..e03730d 100644
--- a/@types/node-gtk/Gst-1.0.d.ts
+++ b/@types/node-gtk/Gst-1.0.d.ts
@@ -3794,16 +3837,17 @@ export interface Pad_ConstructProps extends Object_ConstructProps {
 export class Pad {
     /* Properties of Gst-1.0.Gst.Pad */
     readonly caps: Caps
+    readonly direction: PadDirection
     offset: number
     template: PadTemplate
     /* Fields of Gst-1.0.Gst.Object */
-    readonly object: GObject.InitiallyUnowned
-    readonly lock: GLib.Mutex
-    readonly name: string
-    readonly parent: Object
-    readonly flags: number
+    object: GObject.InitiallyUnowned
+    lock: GLib.Mutex
+    name: string
+    parent: Object
+    flags: number
     /* Fields of GObject-2.0.GObject.InitiallyUnowned */
-    readonly gTypeInstance: GObject.TypeInstance
+    gTypeInstance: GObject.TypeInstance
     /* Methods of Gst-1.0.Gst.Pad */
     activateMode(mode: PadMode, active: boolean): boolean
     addProbe(mask: PadProbeType, callback: PadProbeCallback): number
```

However, I don't understand some other changes that my commit has brought yet. For example, this change to `GLib.Array`:
```patch
diff --git a/@types/node-gtk/GLib-2.0.d.ts b/@types/node-gtk/GLib-2.0.d.ts
index d6e3d4e..2704320 100644
--- a/@types/node-gtk/GLib-2.0.d.ts
+++ b/@types/node-gtk/GLib-2.0.d.ts
@@ -1591,8 +1591,8 @@ export interface VoidFunc {
 }
 export class Array {
     /* Fields of GLib-2.0.GLib.Array */
-    readonly data: string
-    readonly len: number
+    data: string
+    len: number
     static name: string
 }
 export class AsyncQueue {
```

Or this change to classes containing `gTypeInstance`:
```patch
diff --git a/@types/node-gtk/GObject-2.0.d.ts b/@types/node-gtk/GObject-2.0.d.ts
index a1aa14e..be9ad54 100644
--- a/@types/node-gtk/GObject-2.0.d.ts
+++ b/@types/node-gtk/GObject-2.0.d.ts
@@ -417,7 +448,7 @@ export interface InitiallyUnowned_ConstructProps extends Object_ConstructProps {
 }
 export class InitiallyUnowned {
     /* Fields of GObject-2.0.GObject.Object */
-    readonly gTypeInstance: TypeInstance
+    gTypeInstance: TypeInstance
     /* Methods of GObject-2.0.GObject.Object */
     bindProperty(sourceProperty: string, target: Object, targetProperty: string, flags: BindingFlags): Binding
     bindPropertyFull(sourceProperty: string, target: Object, targetProperty: string, flags: BindingFlags, transformTo: F
unction, transformFrom: Function): Binding
```