### PR TITLE
Change engine version to >16

### DIFF
--- a/examples/node-gtk/browser/package.json
+++ b/examples/node-gtk/browser/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16"
+    "node": ">16"
   },
   "devDependencies": {
     "@types/node": "^17.0.23",

--- a/examples/node-gtk/builder-auto-connect-signals/package.json
+++ b/examples/node-gtk/builder-auto-connect-signals/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16"
+    "node": ">16"
   },
   "devDependencies": {
     "@types/node": "^17.0.23",

--- a/examples/node-gtk/builder/package.json
+++ b/examples/node-gtk/builder/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16"
+    "node": ">16"
   },
   "devDependencies": {
     "@types/node": "^17.0.23",

--- a/examples/node-gtk/cli/package.json
+++ b/examples/node-gtk/cli/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16"
+    "node": ">16"
   },
   "devDependencies": {
     "@types/node": "^17.0.23",

--- a/examples/node-gtk/editor/package.json
+++ b/examples/node-gtk/editor/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16"
+    "node": ">16"
   },
   "devDependencies": {
     "@types/node": "^17.0.23",

--- a/examples/node-gtk/hello-gtk/package.json
+++ b/examples/node-gtk/hello-gtk/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16"
+    "node": ">16"
   },
   "devDependencies": {
     "@types/node": "^17.0.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "ts-for-gir": "lib/start.js"
       },
       "devDependencies": {
-        "@types/change-case": "^2.3.1",
         "@types/ejs": "^3.1.0",
         "@types/eslint": "^8.4.1",
         "@types/inquirer": "^8.2.1",
@@ -45,10 +44,10 @@
         "eslint-plugin-prettier": "^4.0.0",
         "rimraf": "^3.0.2",
         "ts-node": "^10.7.0",
-        "typescript": "4.6.3"
+        "typescript": "4.6.4"
       },
       "engines": {
-        "node": "^16"
+        "node": ">16"
       }
     },
     "examples/Gjs/browser": {
@@ -146,7 +145,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "^16"
+        "node": ">16"
       }
     },
     "examples/node-gtk/builder": {
@@ -168,7 +167,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "^16"
+        "node": ">16"
       }
     },
     "examples/node-gtk/builder-auto-connect-signals": {
@@ -189,7 +188,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "^16"
+        "node": ">16"
       }
     },
     "examples/node-gtk/cli": {
@@ -210,7 +209,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "^16"
+        "node": ">16"
       }
     },
     "examples/node-gtk/editor": {
@@ -230,7 +229,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "^16"
+        "node": ">16"
       }
     },
     "examples/node-gtk/hello-gtk": {
@@ -251,7 +250,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "^16"
+        "node": ">16"
       }
     },
     "examples/node-gtk/http": {
@@ -473,14 +472,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/change-case": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "*"
-      }
     },
     "node_modules/@types/ejs": {
       "version": "3.1.0",
@@ -1169,8 +1160,9 @@
       }
     },
     "node_modules/async": {
-      "version": "0.9.2",
-      "license": "MIT"
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1562,15 +1554,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001298",
       "dev": true,
@@ -1578,16 +1561,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
-      }
-    },
-    "node_modules/capital-case": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
       }
     },
     "node_modules/caseless": {
@@ -1614,25 +1587,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/change-case": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/chardet": {
@@ -1934,16 +1888,6 @@
       "version": "1.1.0",
       "license": "ISC"
     },
-    "node_modules/constant-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
@@ -2156,15 +2100,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "license": "MIT",
@@ -2174,10 +2109,11 @@
       }
     },
     "node_modules/ejs": {
-      "version": "3.1.6",
-      "license": "Apache-2.0",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
       "dependencies": {
-        "jake": "^10.6.1"
+        "jake": "^10.8.5"
       },
       "bin": {
         "ejs": "bin/cli.js"
@@ -3084,10 +3020,30 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.2",
-      "license": "Apache-2.0",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "dependencies": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -3523,15 +3479,6 @@
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "license": "ISC"
-    },
-    "node_modules/header-case": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
@@ -4066,11 +4013,12 @@
       "license": "MIT"
     },
     "node_modules/jake": {
-      "version": "10.8.2",
-      "license": "Apache-2.0",
+      "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
       "dependencies": {
-        "async": "0.9.x",
-        "chalk": "^2.4.2",
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
         "filelist": "^1.0.1",
         "minimatch": "^3.0.4"
       },
@@ -4078,47 +4026,41 @@
         "jake": "bin/cli.js"
       },
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/jake/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=10"
       }
     },
     "node_modules/jake/node_modules/chalk": {
-      "version": "2.4.2",
-      "license": "MIT",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jake/node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/jake/node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/jake/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
+    "node_modules/jake/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/jake/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-worker": {
@@ -4384,14 +4326,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "license": "ISC",
@@ -4623,15 +4557,6 @@
       "version": "2.6.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -5097,15 +5022,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "license": "MIT",
@@ -5138,24 +5054,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/path-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -5674,16 +5572,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/sentence-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -5813,15 +5701,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/snake-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/source-map": {
@@ -6384,9 +6263,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6420,22 +6299,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/upper-case": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/uri-js": {
@@ -6986,13 +6849,6 @@
       "version": "1.0.2",
       "dev": true
     },
-    "@types/change-case": {
-      "version": "2.3.1",
-      "dev": true,
-      "requires": {
-        "change-case": "*"
-      }
-    },
     "@types/ejs": {
       "version": "3.1.0",
       "dev": true
@@ -7462,7 +7318,9 @@
       "version": "1.0.0"
     },
     "async": {
-      "version": "0.9.2"
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "asynckit": {
       "version": "0.4.0"
@@ -7677,26 +7535,9 @@
     "callsites": {
       "version": "3.1.0"
     },
-    "camel-case": {
-      "version": "4.1.2",
-      "dev": true,
-      "requires": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "caniuse-lite": {
       "version": "1.0.30001298",
       "dev": true
-    },
-    "capital-case": {
-      "version": "1.0.4",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
     },
     "caseless": {
       "version": "0.12.0"
@@ -7712,24 +7553,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
       "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
-    },
-    "change-case": {
-      "version": "4.1.2",
-      "dev": true,
-      "requires": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
     },
     "chardet": {
       "version": "0.7.0"
@@ -7914,15 +7737,6 @@
     "console-control-strings": {
       "version": "1.1.0"
     },
-    "constant-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
     "convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
@@ -8055,14 +7869,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dot-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "requires": {
@@ -8071,9 +7877,11 @@
       }
     },
     "ejs": {
-      "version": "3.1.6",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
       "requires": {
-        "jake": "^10.6.1"
+        "jake": "^10.8.5"
       }
     },
     "electron-to-chromium": {
@@ -8592,9 +8400,29 @@
       }
     },
     "filelist": {
-      "version": "1.0.2",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^5.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "fill-range": {
@@ -8898,14 +8726,6 @@
     "has-unicode": {
       "version": "2.0.1"
     },
-    "header-case": {
-      "version": "2.0.4",
-      "dev": true,
-      "requires": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "http-signature": {
       "version": "1.2.0",
       "requires": {
@@ -9190,39 +9010,37 @@
       "version": "0.1.2"
     },
     "jake": {
-      "version": "10.8.2",
+      "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
       "requires": {
-        "async": "0.9.x",
-        "chalk": "^2.4.2",
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
         "filelist": "^1.0.1",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
         "chalk": {
-          "version": "2.4.2",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
-        "color-convert": {
-          "version": "1.9.3",
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
-            "color-name": "1.1.3"
+            "has-flag": "^4.0.0"
           }
-        },
-        "color-name": {
-          "version": "1.1.3"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5"
         }
       }
     },
@@ -9394,13 +9212,6 @@
         }
       }
     },
-    "lower-case": {
-      "version": "2.0.2",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
     "lru-cache": {
       "version": "6.0.0",
       "requires": {
@@ -9540,14 +9351,6 @@
     "neo-async": {
       "version": "2.6.2",
       "dev": true
-    },
-    "no-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -9906,14 +9709,6 @@
       "version": "2.2.0",
       "dev": true
     },
-    "param-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "parent-module": {
       "version": "1.0.1",
       "requires": {
@@ -9932,22 +9727,6 @@
     "parse-ms": {
       "version": "2.1.0",
       "dev": true
-    },
-    "pascal-case": {
-      "version": "3.1.2",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "path-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
     },
     "path-exists": {
       "version": "5.0.0",
@@ -10228,15 +10007,6 @@
         "lru-cache": "^6.0.0"
       }
     },
-    "sentence-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
     "serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -10315,14 +10085,6 @@
           "version": "4.0.0",
           "dev": true
         }
-      }
-    },
-    "snake-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "source-map": {
@@ -10583,7 +10345,7 @@
       "version": "file:examples/node-gtk/http",
       "requires": {
         "esbuild": "^0.14.32",
-        "node-gtk": "*"
+        "node-gtk": "^0.10.0"
       }
     },
     "ts-loader": {
@@ -10679,9 +10441,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "unbox-primitive": {
@@ -10701,20 +10463,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
-    },
-    "upper-case": {
-      "version": "2.0.2",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "upper-case-first": {
-      "version": "2.0.2",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
-      }
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "bin": "./lib/start.js",
   "engines": {
-    "node": "^16"
+    "node": ">16"
   },
   "scripts": {
     "start": "node --max_old_space_size=9216 --loader ts-node/esm src/start.ts",
@@ -70,7 +70,6 @@
   },
   "homepage": "https://github.com/sammydre/ts-for-gjs#readme",
   "devDependencies": {
-    "@types/change-case": "^2.3.1",
     "@types/ejs": "^3.1.0",
     "@types/eslint": "^8.4.1",
     "@types/inquirer": "^8.2.1",
@@ -87,7 +86,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "rimraf": "^3.0.2",
     "ts-node": "^10.7.0",
-    "typescript": "4.6.3"
+    "typescript": "4.6.4"
   },
   "dependencies": {
     "chalk": "^5.0.1",


### PR DESCRIPTION
 Hello,
 
 This PR address the issue #64 and also updates some dependencies  

Changes:
 - Remove @types/change-case dep, not necessary anymore
 - Update async and ejs due to vulnerabilities (npm audit fix)
 - Update TypeScript minor version