### PR TITLE
Revert removal of imports.versions

### DIFF
--- a/templates/Gjs/index.d.ts
+++ b/templates/Gjs/index.d.ts
@@ -257,6 +257,16 @@ declare global {
             <%_ } _%>
           <%_ } _%>
         }
+        versions: {
+          <%_ for (const girModuleGroup of girModulesGrouped) { _%>
+            <%= girModuleGroup.namespace %>: <%_ for (const [i, girModule] of girModuleGroup.modules.entries()) { _%>
+              '<%= girModule.module.version %>'
+              <%_ if (i !== girModuleGroup.modules.length - 1) { _%>
+                |
+              <%_ } _%>
+            <%_ } _%>
+          <%_ } _%>
+        }
         lang: typeof Gjs.Lang
         system: typeof Gjs.System
         package: typeof Gjs.Package


### PR DESCRIPTION
Hello,

This PR intends to revert a [mistake I made](https://github.com/sammydre/ts-for-gir/pull/67/files#diff-a6b8083e7461cce7cc3413ca471e7d9d0a8bdf18911a2a6e777c0fcbc689f12bL260-L269) in #67, which was the removal of the global definition for `imports.verision`