### PR TITLE
Tell tsc to expect error on gi ESM imports

### DIFF
--- a/templates/Gjs/module.js
+++ b/templates/Gjs/module.js
@@ -1,14 +1,15 @@
 <% if(moduleType === 'esm'){ %>
+// @ts-expect-error
 import <%= name %> from 'gi://<%= name %>?version=<%= version %>';
 export { <%= name %> };
 export default <%= name %>;
-<% } else { %>  
+<% } else { %>
 imports.gi.versions.<%= name %> = '<%= version %>'
 const <%= name %> = imports.gi.<%= name %>;
   <% if(useNamespace){ %>
 module.exports = { <%= name %> };
 exports.default = <%= name %>;
-  <% } else { %>  
+  <% } else { %>
 module.exports = <%= name %>;
   <% } %>
 <% } %>


### PR DESCRIPTION
Hello,

Currently, when using the type definitions generated by this tool with the Typescript compiler it complains about not being able to find the modules imported by the generated .js files

![image](https://user-images.githubusercontent.com/9082460/170423727-028fa518-f6b4-490f-927f-748e8d48b8d6.png)

This is an expected behaviour considering TS doesn't understand `gi://` imports, and that doesn't really impact its type checking due to it resolving everything through the `d.ts` files.

So, this PR adds to the `module.js` template, used to generate the `.js` files, a `@ts-expect-error` annotation on top of the `gi://` imports to avoid TS compiling errors