### PR TITLE
Improve log/logError argument types

### DIFF
--- a/templates/Gjs/index.d.ts
+++ b/templates/Gjs/index.d.ts
@@ -18,7 +18,7 @@ import type * as <%= girModule.importName %> from "./<%= girModule.packageName %
 declare global {
     function print(...args: any[]): void
     function printerr(...args: any[]): void
-    function log(message?: any): void
+    function log(message: any): void
     function logError(exception: object, message?: any): void
 
     interface Console {

--- a/templates/Gjs/index.d.ts
+++ b/templates/Gjs/index.d.ts
@@ -18,8 +18,8 @@ import type * as <%= girModule.importName %> from "./<%= girModule.packageName %
 declare global {
     function print(...args: any[]): void
     function printerr(...args: any[]): void
-    function log(message?: string): void
-    function logError(exception: any, message?: string): void
+    function log(message?: any): void
+    function logError(exception: object, message?: any): void
 
     interface Console {
         /**


### PR DESCRIPTION
Hello,

This PR is a simple improvement to the type definition of log/logError's arguments.

According to gjs implementation, the `log` function takes a required `any` typed argument, as it internally convert it to string, by calling the `ToString` method:
https://gitlab.gnome.org/GNOME/gjs/-/blob/1.72.0/modules/print.cpp#L29-32
https://gitlab.gnome.org/GNOME/gjs/-/blob/1.72.0/modules/print.cpp#L37

![image](https://user-images.githubusercontent.com/9082460/176586315-bbdde54b-4cb6-418e-bd98-19c39b55599a.png)

Also, `logError` requires a more restrictive type for the `exception` argument, as it throws an Exception if it is any primitive type (such as: string, number, bigint, boolean, undefined, symbol, and null) and only accepts objects. As for the `message` argument, it accepts `any` because it converts it to string just like `log` above:
https://gitlab.gnome.org/GNOME/gjs/-/blob/1.72.0/modules/print.cpp#L59-64
https://gitlab.gnome.org/GNOME/gjs/-/blob/1.72.0/modules/print.cpp#L72

![image](https://user-images.githubusercontent.com/9082460/176586635-b4e8de94-bbbb-4f8e-b0c7-f87bd65c30a3.png)
 
