### PR TITLE
Fix prepend logic in Logger's static methods

### DIFF
--- a/packages/cli/src/logger.ts
+++ b/packages/cli/src/logger.ts
@@ -104,19 +104,19 @@ export class Logger {
         return
     }
     public static info(txt: string | number, ...args: unknown[]): void {
-        args = this.prepend([txt], 'INFO: ')
+        ;[txt, ...args] = this.prepend([txt, ...args], 'INFO: ') as [string, ...unknown[]]
         return console.info(blue(txt), ...args)
     }
     public static warn(txt: string | number, ...args: unknown[]): void {
-        args = this.prepend([txt], 'WARN: ')
+        ;[txt, ...args] = this.prepend([txt, ...args], 'WARN: ') as [string, ...unknown[]]
         return console.warn(yellow(txt), ...args)
     }
     public static debug(txt: string | number, ...args: unknown[]): void {
-        args = this.prepend([txt], 'DEBUG: ')
+        ;[txt, ...args] = this.prepend([txt, ...args], 'DEBUG: ') as [string, ...unknown[]]
         return console.debug(yellowBright(txt), ...args)
     }
     public static error(txt: string | number, ...args: unknown[]): void {
-        args = this.prepend([txt], 'ERROR: ')
+        ;[txt, ...args] = this.prepend([txt, ...args], 'ERROR: ') as [string, ...unknown[]]
         return this.danger(txt, args)
     }
     public static success(txt: string | number, ...args: unknown[]): void {


### PR DESCRIPTION
Hello,

This PR fix a bug in Logger's static methods that result in the messages being printed twice:
![image](https://user-images.githubusercontent.com/9082460/189978016-fa9f9b03-fc2c-402b-a838-f1c7dd6a7152.png)
With the following changes:
![image](https://user-images.githubusercontent.com/9082460/189978168-62629db4-08d2-4c05-8c2c-dc6ebabfb699.png)
