### PR TITLE
Expose GIRepositoryNamespace underscore properties in TS namespace

### DIFF
--- a/packages/cli/src/type-definition-generator.ts
+++ b/packages/cli/src/type-definition-generator.ts
@@ -1280,6 +1280,11 @@ export default class TypeDefinitionGenerator implements Generator {
                 for (const girAlias of girModule.ns.alias)
                     if (girModule.packageName !== 'GObject-2.0' || girAlias.$.name !== 'Type')
                         out.push(...this.generateAlias(girAlias, girModule.namespace, 1))
+
+            // Properties added to every GIRepositoryNamespace
+            // https://gitlab.gnome.org/GNOME/gjs/-/blob/master/gi/ns.cpp#L186-190
+            out.push('const __name__: string')
+            out.push('const __version__: string')
         }
         // END Namespace
         if (this.config.useNamespace) {

--- a/packages/cli/src/type-definition-generator.ts
+++ b/packages/cli/src/type-definition-generator.ts
@@ -1281,10 +1281,76 @@ export default class TypeDefinitionGenerator implements Generator {
                     if (girModule.packageName !== 'GObject-2.0' || girAlias.$.name !== 'Type')
                         out.push(...this.generateAlias(girAlias, girModule.namespace, 1))
 
-            // Properties added to every GIRepositoryNamespace
-            // https://gitlab.gnome.org/GNOME/gjs/-/blob/master/gi/ns.cpp#L186-190
-            out.push('const __name__: string')
-            out.push('const __version__: string')
+            if (this.config.environment === 'gjs') {
+                // Properties added to every GIRepositoryNamespace
+                // https://gitlab.gnome.org/GNOME/gjs/-/blob/master/gi/ns.cpp#L186-190
+                out.push(
+                    ...this.generateConstant(
+                        {
+                            doc: {
+                                text: 'Name of the imported GIR library',
+                                tags: [
+                                    {
+                                        text: 'https://gitlab.gnome.org/GNOME/gjs/-/blob/master/gi/ns.cpp#L188',
+                                        tagName: 'see',
+                                        paramName: '',
+                                    },
+                                ],
+                            },
+                            name: '__name__',
+                            type: [
+                                {
+                                    type: 'string',
+                                    optional: false,
+                                    nullable: false,
+                                    callbacks: [],
+                                    generics: [],
+                                    isArray: false,
+                                    isFunction: false,
+                                    isCallback: false,
+                                },
+                            ],
+                            isInjected: false,
+                            tsTypeName: 'constant',
+                            girTypeName: 'constant',
+                        },
+                        girModule.namespace,
+                        0,
+                    ),
+                    ...this.generateConstant(
+                        {
+                            doc: {
+                                text: 'Version of the imported GIR library',
+                                tags: [
+                                    {
+                                        text: 'https://gitlab.gnome.org/GNOME/gjs/-/blob/master/gi/ns.cpp#L189',
+                                        tagName: 'see',
+                                        paramName: '',
+                                    },
+                                ],
+                            },
+                            name: '__version__',
+                            type: [
+                                {
+                                    type: 'string',
+                                    optional: false,
+                                    nullable: false,
+                                    callbacks: [],
+                                    generics: [],
+                                    isArray: false,
+                                    isFunction: false,
+                                    isCallback: false,
+                                },
+                            ],
+                            isInjected: false,
+                            tsTypeName: 'constant',
+                            girTypeName: 'constant',
+                        },
+                        girModule.namespace,
+                        0,
+                    ),
+                )
+            }
         }
         // END Namespace
         if (this.config.useNamespace) {


### PR DESCRIPTION
Hello,

In GJS's source code, all GIRepositoryNamespace (Object representing imported GIR libraries) expose two underscored properties containing the lib name and version:
https://gitlab.gnome.org/GNOME/gjs/-/blob/master/gi/ns.cpp#L186-190

This PR exposes those properties in the Typescript namespace definition for each processed lib.