### PR TITLE
Solution for #72 + Add type definitions for Text(D)Encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ And then create a new script in your `package.json` to generate the types, for e
 
 more examples can be found in the [./examples/](/examples/) subfolder.
 
+### For GJS projects
+It's recommended that you create or modify your `tsconfig.json`/`jsconfig.json`, so it doesn't include the `DOM` lib, as it conflicts with some generated GJS global types and will cause lint warnings and compilation errors with typescript.
+
+Either add/edit the `lib` property so it doesn't include `"DOM"`, or enable the property `noLib` (However the side effects of doing this should be considered). For more information check the documentation for both the [`lib`](https://www.typescriptlang.org/tsconfig/#lib) and [`noLib`](https://www.typescriptlang.org/tsconfig#noLib) properties.
+
 ### CLI
 
 To generate the Typescript type definitions of Gtk-4.0 for Gjs run

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,8 +52,7 @@
     "eslint": "^8.20.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "rimraf": "^3.0.2",
-    "typescript": "4.7.4"
+    "rimraf": "^3.0.2"
   },
   "dependencies": {
     "colorette": "^2.0.19",
@@ -66,6 +65,7 @@
     "lodash": "^4.17.21",
     "prettier": "^2.7.1",
     "tiny-glob": "^0.2.9",
+    "typescript": "4.7.4",
     "xml2js": "^0.4.23",
     "yargs": "^17.5.1"
   }

--- a/packages/cli/src/messages.ts
+++ b/packages/cli/src/messages.ts
@@ -57,9 +57,6 @@ export const WARN_RENAMED_ENUM = (originalName: string, newName: string) =>
 export const WARN_RENAMED_PARAMETER = (originalName: string, newName: string) =>
     `Parameter name renamed from '${originalName}' to '${newName}'`
 
-export const WARN_HAS_DOM_LIB = `The project where definition will be generated is not configured or includes the DOM library in its tsconfig.json or jsconfig.json.
-This conflicts with some gjs global definitions and as such those will no be included.`
-
 // Info messages
 
 export const DANGER_HTML_DOC_GENERATOR_NOT_IMPLEMENTED =

--- a/packages/cli/src/messages.ts
+++ b/packages/cli/src/messages.ts
@@ -57,6 +57,9 @@ export const WARN_RENAMED_ENUM = (originalName: string, newName: string) =>
 export const WARN_RENAMED_PARAMETER = (originalName: string, newName: string) =>
     `Parameter name renamed from '${originalName}' to '${newName}'`
 
+export const WARN_HAS_DOM_LIB = `The project where definition will be generated is not configured or includes the DOM library in its tsconfig.json or jsconfig.json.
+This conflicts with some gjs global definitions and as such those will no be included.`
+
 // Info messages
 
 export const DANGER_HTML_DOC_GENERATOR_NOT_IMPLEMENTED =

--- a/packages/cli/src/types/generate-config.ts
+++ b/packages/cli/src/types/generate-config.ts
@@ -28,4 +28,6 @@ export interface GenerateConfig {
     noCheck: boolean
     /** Fix Inheritance and implementation type conflicts */
     fixConflicts: boolean
+    /** Wheter the project has DOM lib enabled in tsconfig/jsconfig */
+    hasDOMLib: boolean
 }

--- a/packages/cli/src/types/user-config.ts
+++ b/packages/cli/src/types/user-config.ts
@@ -36,4 +36,6 @@ export interface UserConfig {
     noCheck: boolean
     /** Fix Inheritance and implementation type conflicts */
     fixConflicts: boolean
+    /** Wheter the project has DOM lib enabled in tsconfig/jsconfig */
+    hasDOMLib: boolean
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -238,8 +238,6 @@ function convertTsJsConfigToObject(path: string) {
  * @param path - The directory path to search for a tsconfig.json or jsconfig.json file
  */
 export function readTsJsConfig(path: string) {
-    if (!fs.lstatSync(path, { throwIfNoEntry: false })?.isDirectory()) return null
-
     let config: null | false | Record<PropertyKey, unknown> = null
     let lastPath = ''
     let currentPath = Path.resolve(path)

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -2,6 +2,7 @@
 import lodash from 'lodash'
 import Path from 'path'
 import fs from 'fs'
+import ts from 'typescript'
 import { fileURLToPath } from 'url'
 import { Environment, GirInfoAttrs, TsType } from './types/index.js'
 import { inspect } from 'util'
@@ -218,7 +219,10 @@ export const typeIsOptional = (types: TsType[]) => {
 
 function convertTsJsConfigToObject(path: string) {
     try {
-        const config: unknown = JSON.parse(fs.readFileSync(path, 'utf8'))
+        const config: unknown = ts.parseConfigFileTextToJson(
+            Path.basename(path),
+            fs.readFileSync(path, 'utf8').trim(),
+        ).config
         if (typeof config === 'object' && !Array.isArray(config)) return config as Record<PropertyKey, unknown>
     } catch {
         // ignored
@@ -238,7 +242,7 @@ export function readTsJsConfig(path: string) {
 
     let config: null | false | Record<PropertyKey, unknown> = null
     let lastPath = ''
-    let currentPath = path
+    let currentPath = Path.resolve(path)
     while (!config && currentPath !== lastPath) {
         const tsConfigPath = Path.join(currentPath, 'tsconfig.json')
         const jsConfigPath = Path.join(currentPath, 'jsconfig.json')

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -215,3 +215,39 @@ export const typeIsOptional = (types: TsType[]) => {
     }
     return false
 }
+
+function convertTsJsConfigToObject(path: string) {
+    try {
+        const config: unknown = JSON.parse(fs.readFileSync(path, 'utf8'))
+        if (typeof config === 'object' && !Array.isArray(config)) return config as Record<PropertyKey, unknown>
+    } catch {
+        // ignored
+    }
+    return null
+}
+
+/**
+ * Given an directory path search for a tsconfig.json or jsconfig.json file in it or any of its parent directories, then read the file and parse it as json.
+ * @see {@link https://github.com/microsoft/TypeScript/blob/5f9c9a6ccf61fa131849797248438e292e7b496a/src/harness/compilerImpl.ts#L11-L35}
+ * @see {@link https://github.com/microsoft/TypeScript/blob/3fd8a6e44341f14681aa9d303dc380020ccb2147/src/harness/vfsUtil.ts#L286-L316}
+ *
+ * @param path - The directory path to search for a tsconfig.json or jsconfig.json file
+ */
+export function readTsJsConfig(path: string) {
+    if (!fs.lstatSync(path, { throwIfNoEntry: false })?.isDirectory()) return null
+
+    let config: null | false | Record<PropertyKey, unknown> = null
+    let lastPath = ''
+    let currentPath = path
+    while (!config && currentPath !== lastPath) {
+        const tsConfigPath = Path.join(currentPath, 'tsconfig.json')
+        const jsConfigPath = Path.join(currentPath, 'jsconfig.json')
+        config =
+            (fs.existsSync(tsConfigPath) && convertTsJsConfigToObject(tsConfigPath)) ||
+            (fs.existsSync(jsConfigPath) && convertTsJsConfigToObject(jsConfigPath))
+        lastPath = currentPath
+        currentPath = Path.dirname(currentPath)
+    }
+
+    return config === false ? null : config
+}

--- a/packages/cli/templates/Gjs/index.d.ts
+++ b/packages/cli/templates/Gjs/index.d.ts
@@ -199,9 +199,11 @@ declare global {
         logDomain: string
     }
 
+    <% if(!hasDOMLib){ %>
     const console: Console
+    <% } %>
 
-    // https://gitlab.gnome.org/GNOME/gjs/-/blob/1.72.0/modules/esm/_encoding/encodingMap.js#L7-232
+    // https://gitlab.gnome.org/GNOME/gjs/-/blob/1.73.2/modules/esm/_encoding/encodingMap.js#L7-232
     type TextDecoderEncoding =
         | 'unicode-1-1-utf-8'
         | 'unicode11utf8'
@@ -425,7 +427,7 @@ declare global {
         | 'utf-16le'
 
     interface TextDecodeOptions {
-        // A of Gjs 1.72.0 stream mode is not supported yet.
+        // As of Gjs 1.73.2 stream mode is not supported yet.
         // stream?: boolean
     }
 
@@ -440,7 +442,7 @@ declare global {
      * The TextDecoder interface represents a decoder for a specific text encoding.
      * It takes a stream of bytes as input and emits a stream of code points.
      *
-     * @since Gjs 1.69.2
+     * @version Gjs 1.69.2
      */
     interface TextDecoder {
         /** A string containing the name of the decoder, that is a string describing the method the TextDecoder will use. */
@@ -461,10 +463,12 @@ declare global {
         decode(input?: ArrayBufferView | ArrayBuffer, options?: TextDecodeOptions): string
     }
 
+    <% if(!hasDOMLib){ %>
     const TextDecoder: {
-        prototype: TextDecoder
-        new (label?: TextDecoderEncoding, options?: TextDecoderOptions): TextDecoder
+      prototype: TextDecoder
+      new (label?: TextDecoderEncoding, options?: TextDecoderOptions): TextDecoder
     }
+    <% } %>
 
     interface TextEncoderEncodeIntoResult {
         read?: number
@@ -474,7 +478,7 @@ declare global {
     /**
      * TextEncoder takes a stream of code points as input and emits a stream of bytes.
      *
-     * @since Gjs 1.69.2
+     * @version Gjs 1.69.2
      */
     interface TextEncoder {
         readonly encoding: 'utf-8'
@@ -497,10 +501,12 @@ declare global {
         encodeInto(source: string, destination: Uint8Array): TextEncoderEncodeIntoResult
     }
 
+    <% if(!hasDOMLib){ %>
     const TextEncoder: {
         prototype: TextEncoder
         new (): TextEncoder
     }
+    <% } %>
 
     interface BooleanConstructor {
         $gtype: GObject20.GType<boolean>
@@ -520,7 +526,7 @@ declare global {
     // See https://gitlab.gnome.org/GNOME/gjs/-/blob/master/modules/esm/_timers.js
 
     /**
-     * @since Gjs 1.71.1
+     * @version Gjs 1.71.1
      * @param callback a callback function
      * @param delay the duration in milliseconds to wait before running callback
      * @param args arguments to pass to callback
@@ -528,7 +534,7 @@ declare global {
     function setTimeout(callback: (...args: any[]) => any, delay?: number, ...args: any[]): GLib20.Source
 
     /**
-     * @since Gjs 1.71.1
+     * @version Gjs 1.71.1
      * @param callback a callback function
      * @param delay the duration in milliseconds to wait between calling callback
      * @param args arguments to pass to callback
@@ -536,13 +542,13 @@ declare global {
     function setInterval(callback: (...args: any[]) => any, delay?: number, ...args: any[]): GLib20.Source
 
     /**
-     * @since Gjs 1.71.1
+     * @version Gjs 1.71.1
      * @param timeout the timeout to clear
      */
     function clearTimeout(timeout: GLib20.Source): void
 
     /**
-     * @since Gjs 1.71.1
+     * @version Gjs 1.71.1
      * @param timeout the timeout to clear
      */
     function clearInterval(timeout: GLib20.Source): void

--- a/packages/cli/templates/Gjs/index.d.ts
+++ b/packages/cli/templates/Gjs/index.d.ts
@@ -199,9 +199,65 @@ declare global {
         logDomain: string
     }
 
-    // Ignore "Cannot redeclare block-scoped variable 'console'""
-    // @ts-ignore
-    const console: Console;
+    const console: Console
+
+    /** A decoder for a specific method, that is a specific character encoding, like utf-8, iso-8859-2, koi8, cp1261, gbk, etc. A decoder takes a stream of bytes as input and emits a stream of code points. For a more scalable, non-native library, see StringView – a C-like representation of strings based on typed arrays. */
+    interface TextDecoder {
+        /**
+         * Returns encoding's name, lowercased.
+         */
+        readonly encoding: string
+        /**
+         * Returns true if error mode is "fatal", otherwise false.
+         */
+        readonly fatal: boolean
+        /**
+         * Returns the value of ignore BOM.
+         */
+        readonly ignoreBOM: boolean
+
+        /**
+         * Returns the result of running encoding's decoder. The method can be invoked zero or more times with options's stream set to true, and then once without options's stream (or set to false), to process a fragmented input. If the invocation without options's stream (or set to false) has no input, it's clearest to omit both arguments.
+         *
+         * ```
+         * var string = "", decoder = new TextDecoder(encoding), buffer;
+         * while(buffer = next_chunk()) {
+         *   string += decoder.decode(buffer, {stream:true});
+         * }
+         * string += decoder.decode(); // end-of-queue
+         * ```
+         *
+         * If the error mode is "fatal" and encoding's decoder returns error, throws a TypeError.
+         */
+        decode(input?: BufferSource, options?: TextDecodeOptions): string
+    }
+
+    const TextDecoder: {
+        prototype: TextDecoder
+        new (label?: string, options?: TextDecoderOptions): TextDecoder
+    }
+
+    /** TextEncoder takes a stream of code points as input and emits a stream of bytes. For a more scalable, non-native library, see StringView – a C-like representation of strings based on typed arrays. */
+    interface TextEncoder {
+        /**
+         * Returns "utf-8".
+         */
+        readonly encoding: string
+
+        /**
+         * Returns the result of running UTF-8's encoder.
+         */
+        encode(input?: string): Uint8Array
+        /**
+         * Runs the UTF-8 encoder on source, stores the result of that operation into destination, and returns the progress made as an object wherein read is the number of converted code units of source and written is the number of bytes modified in destination.
+         */
+        encodeInto(source: string, destination: Uint8Array): TextEncoderEncodeIntoResult
+    }
+
+    const TextEncoder: {
+        prototype: TextEncoder
+        new (): TextEncoder
+    }
 
     interface BooleanConstructor {
         $gtype: GObject20.GType<boolean>

--- a/packages/cli/templates/Gjs/index.d.ts
+++ b/packages/cli/templates/Gjs/index.d.ts
@@ -201,55 +201,298 @@ declare global {
 
     const console: Console
 
-    /** A decoder for a specific method, that is a specific character encoding, like utf-8, iso-8859-2, koi8, cp1261, gbk, etc. A decoder takes a stream of bytes as input and emits a stream of code points. For a more scalable, non-native library, see StringView – a C-like representation of strings based on typed arrays. */
+    // https://gitlab.gnome.org/GNOME/gjs/-/blob/1.72.0/modules/esm/_encoding/encodingMap.js#L7-232
+    type TextDecoderEncoding =
+        | 'unicode-1-1-utf-8'
+        | 'unicode11utf8'
+        | 'unicode20utf8'
+        | 'utf-8'
+        | 'utf8'
+        | 'x-unicode20utf8'
+        | '866'
+        | 'cp866'
+        | 'csibm866'
+        | 'ibm866'
+        | 'csisolatin2'
+        | 'iso-8859-2'
+        | 'iso-ir-101'
+        | 'iso8859-2'
+        | 'iso88592'
+        | 'iso_8859-2'
+        | 'iso_8859-2:1987'
+        | 'l2'
+        | 'latin2'
+        | 'csisolatin3'
+        | 'iso-8859-3'
+        | 'iso-ir-109'
+        | 'iso8859-3'
+        | 'iso88593'
+        | 'iso_8859-3'
+        | 'iso_8859-3:1988'
+        | 'l3'
+        | 'latin3'
+        | 'csisolatin4'
+        | 'iso-8859-4'
+        | 'iso-ir-110'
+        | 'iso8859-4'
+        | 'iso88594'
+        | 'iso_8859-4'
+        | 'iso_8859-4:1988'
+        | 'l4'
+        | 'latin4'
+        | 'csisolatincyrillic'
+        | 'cyrillic'
+        | 'iso-8859-5'
+        | 'iso-ir-144'
+        | 'iso8859-5'
+        | 'iso88595'
+        | 'iso_8859-5'
+        | 'iso_8859-5:1988'
+        | 'arabic'
+        | 'asmo-708'
+        | 'csiso88596e'
+        | 'csiso88596i'
+        | 'csisolatinarabic'
+        | 'ecma-114'
+        | 'iso-8859-6'
+        | 'iso-8859-6-e'
+        | 'iso-8859-6-i'
+        | 'iso-ir-127'
+        | 'iso8859-6'
+        | 'iso88596'
+        | 'iso_8859-6'
+        | 'iso_8859-6:1987'
+        | 'csisolatingreek'
+        | 'ecma-118'
+        | 'elot_928'
+        | 'greek'
+        | 'greek8'
+        | 'iso-8859-7'
+        | 'iso-ir-126'
+        | 'iso8859-7'
+        | 'iso88597'
+        | 'iso_8859-7'
+        | 'iso_8859-7:1987'
+        | 'sun_eu_greek'
+        | 'csiso88598e'
+        | 'csisolatinhebrew'
+        | 'hebrew'
+        | 'iso-8859-8'
+        | 'iso-8859-8-e'
+        | 'iso-ir-138'
+        | 'iso8859-8'
+        | 'iso88598'
+        | 'iso_8859-8'
+        | 'iso_8859-8:1988'
+        | 'visual'
+        | 'csiso88598i'
+        | 'iso-8859-8-i'
+        | 'logical'
+        | 'csisolatin6'
+        | 'iso-8859-10'
+        | 'iso-ir-157'
+        | 'iso8859-10'
+        | 'iso885910'
+        | 'l6'
+        | 'latin6'
+        | 'iso-8859-13'
+        | 'iso8859-13'
+        | 'iso885913'
+        | 'iso-8859-14'
+        | 'iso8859-14'
+        | 'iso885914'
+        | 'csisolatin9'
+        | 'iso-8859-15'
+        | 'iso8859-15'
+        | 'iso885915'
+        | 'iso_8859-15'
+        | 'l9'
+        | 'iso-8859-16'
+        | 'cskoi8r'
+        | 'koi'
+        | 'koi8'
+        | 'koi8-r'
+        | 'koi8_r'
+        | 'koi8-ru'
+        | 'koi8-u'
+        | 'csmacintosh'
+        | 'mac'
+        | 'macintosh'
+        | 'x-mac-roman'
+        | 'dos-874'
+        | 'iso-8859-11'
+        | 'iso8859-11'
+        | 'iso885911'
+        | 'tis-620'
+        | 'windows-874'
+        | 'cp1250'
+        | 'windows-1250'
+        | 'x-cp1250'
+        | 'cp1251'
+        | 'windows-1251'
+        | 'x-cp1251'
+        | 'ansi_x3.4-1968'
+        | 'ascii'
+        | 'cp1252'
+        | 'cp819'
+        | 'csisolatin1'
+        | 'ibm819'
+        | 'iso-8859-1'
+        | 'iso-ir-100'
+        | 'iso8859-1'
+        | 'iso88591'
+        | 'iso_8859-1'
+        | 'iso_8859-1:1987'
+        | 'l1'
+        | 'latin1'
+        | 'us-ascii'
+        | 'windows-1252'
+        | 'x-cp1252'
+        | 'cp1253'
+        | 'windows-1253'
+        | 'x-cp1253'
+        | 'cp1254'
+        | 'csisolatin5'
+        | 'iso-8859-9'
+        | 'iso-ir-148'
+        | 'iso8859-9'
+        | 'iso88599'
+        | 'iso_8859-9'
+        | 'iso_8859-9:1989'
+        | 'l5'
+        | 'latin5'
+        | 'windows-1254'
+        | 'x-cp1254'
+        | 'cp1255'
+        | 'windows-1255'
+        | 'x-cp1255'
+        | 'cp1256'
+        | 'windows-1256'
+        | 'x-cp1256'
+        | 'cp1257'
+        | 'windows-1257'
+        | 'x-cp1257'
+        | 'cp1258'
+        | 'windows-1258'
+        | 'x-cp1258'
+        | 'x-mac-cyrillic'
+        | 'x-mac-ukrainian'
+        | 'chinese'
+        | 'csgb2312'
+        | 'csiso58gb231280'
+        | 'gb2312'
+        | 'gb_2312'
+        | 'gb_2312-80'
+        | 'gbk'
+        | 'iso-ir-58'
+        | 'x-gbk'
+        | 'gb18030'
+        | 'big5'
+        | 'cn-big5'
+        | 'csbig5'
+        | 'x-x-big5'
+        | 'cseucpkdfmtjapanese'
+        | 'euc-jp'
+        | 'x-euc-jp'
+        | 'csiso2022jp'
+        | 'iso-2022-jp'
+        | 'csshiftjis'
+        | 'ms932'
+        | 'ms_kanji'
+        | 'shift-jis'
+        | 'shift_jis'
+        | 'sjis'
+        | 'windows-31j'
+        | 'x-sjis'
+        | 'cseuckr'
+        | 'csksc56011987'
+        | 'euc-kr'
+        | 'iso-ir-149'
+        | 'korean'
+        | 'ks_c_5601-1987'
+        | 'ks_c_5601-1989'
+        | 'ksc5601'
+        | 'ksc_5601'
+        | 'windows-949'
+        | 'unicodefffe'
+        | 'utf-16be'
+        | 'csunicode'
+        | 'iso-10646-ucs-2'
+        | 'ucs-2'
+        | 'unicode'
+        | 'unicodefeff'
+        | 'utf-16'
+        | 'utf-16le'
+
+    interface TextDecodeOptions {
+        // A of Gjs 1.72.0 stream mode is not supported yet.
+        // stream?: boolean
+    }
+
+    interface TextDecoderOptions {
+        /** Indicates whether the error mode is fatal. */
+        fatal?: boolean
+        /** Indicates whether whether the byte order mark is ignored. */
+        ignoreBOM?: boolean
+    }
+
+    /**
+     * The TextDecoder interface represents a decoder for a specific text encoding.
+     * It takes a stream of bytes as input and emits a stream of code points.
+     *
+     * @since Gjs 1.69.2
+     */
     interface TextDecoder {
-        /**
-         * Returns encoding's name, lowercased.
-         */
-        readonly encoding: string
-        /**
-         * Returns true if error mode is "fatal", otherwise false.
-         */
+        /** A string containing the name of the decoder, that is a string describing the method the TextDecoder will use. */
+        readonly encoding: TextDecoderEncoding
+        /** A Boolean indicating whether the error mode is fatal. */
         readonly fatal: boolean
-        /**
-         * Returns the value of ignore BOM.
-         */
+        /** A Boolean indicating whether the byte order mark is ignored. */
         readonly ignoreBOM: boolean
 
         /**
-         * Returns the result of running encoding's decoder. The method can be invoked zero or more times with options's stream set to true, and then once without options's stream (or set to false), to process a fragmented input. If the invocation without options's stream (or set to false) has no input, it's clearest to omit both arguments.
+         * Returns a string containing the text decoded with the method of the specific TextDecoder object.
          *
-         * ```
-         * var string = "", decoder = new TextDecoder(encoding), buffer;
-         * while(buffer = next_chunk()) {
-         *   string += decoder.decode(buffer, {stream:true});
-         * }
-         * string += decoder.decode(); // end-of-queue
-         * ```
+         * If the error mode is "fatal" and the encoder method encounter an error it WILL THROW a TypeError.
          *
-         * If the error mode is "fatal" and encoding's decoder returns error, throws a TypeError.
+         * @param input Buffer containing the text to decode
+         * @param options Object defining the decode options
          */
-        decode(input?: BufferSource, options?: TextDecodeOptions): string
+        decode(input?: ArrayBufferView | ArrayBuffer, options?: TextDecodeOptions): string
     }
 
     const TextDecoder: {
         prototype: TextDecoder
-        new (label?: string, options?: TextDecoderOptions): TextDecoder
+        new (label?: TextDecoderEncoding, options?: TextDecoderOptions): TextDecoder
     }
 
-    /** TextEncoder takes a stream of code points as input and emits a stream of bytes. For a more scalable, non-native library, see StringView – a C-like representation of strings based on typed arrays. */
+    interface TextEncoderEncodeIntoResult {
+        read?: number
+        written?: number
+    }
+
+    /**
+     * TextEncoder takes a stream of code points as input and emits a stream of bytes.
+     *
+     * @since Gjs 1.69.2
+     */
     interface TextEncoder {
-        /**
-         * Returns "utf-8".
-         */
-        readonly encoding: string
+        readonly encoding: 'utf-8'
 
         /**
-         * Returns the result of running UTF-8's encoder.
+         * Takes a string as input, and returns a buffer containing the text given in parameters encoded with the UTF-8 method.
+         *
+         * @param input Text to encode.
          */
         encode(input?: string): Uint8Array
         /**
-         * Runs the UTF-8 encoder on source, stores the result of that operation into destination, and returns the progress made as an object wherein read is the number of converted code units of source and written is the number of bytes modified in destination.
+         * Takes a string to encode and a destination Uint8Array to put resulting UTF-8 encoded text into,
+         * and returns a dictionary object indicating the progress of the encoding.
+         *
+         * This is potentially more performant than the older encode() method.
+         *
+         * @param source Text to enconde.
+         * @param destination Buffer where to place the resulting UTF-8 encoded text into.
          */
         encodeInto(source: string, destination: Uint8Array): TextEncoderEncodeIntoResult
     }
@@ -277,7 +520,7 @@ declare global {
     // See https://gitlab.gnome.org/GNOME/gjs/-/blob/master/modules/esm/_timers.js
 
     /**
-     * @version Gjs 1.71.1
+     * @since Gjs 1.71.1
      * @param callback a callback function
      * @param delay the duration in milliseconds to wait before running callback
      * @param args arguments to pass to callback
@@ -285,7 +528,7 @@ declare global {
     function setTimeout(callback: (...args: any[]) => any, delay?: number, ...args: any[]): GLib20.Source
 
     /**
-     * @version Gjs 1.71.1
+     * @since Gjs 1.71.1
      * @param callback a callback function
      * @param delay the duration in milliseconds to wait between calling callback
      * @param args arguments to pass to callback
@@ -293,13 +536,13 @@ declare global {
     function setInterval(callback: (...args: any[]) => any, delay?: number, ...args: any[]): GLib20.Source
 
     /**
-     * @version Gjs 1.71.1
+     * @since Gjs 1.71.1
      * @param timeout the timeout to clear
      */
     function clearTimeout(timeout: GLib20.Source): void
 
     /**
-     * @version Gjs 1.71.1
+     * @since Gjs 1.71.1
      * @param timeout the timeout to clear
      */
     function clearInterval(timeout: GLib20.Source): void


### PR DESCRIPTION
Hello,

This PR presents a solution for #72. It adds a notice to the README informing users that it is recommended to edit their `tsconfig.json` file for GJS projects. Besides, logic was built to check, during runtime, if the project has the `DOM` lib in its `tsconfig.json` and if that is the case ask the user if he wants to skip generating any conflicting type.

Also, included in this PR are the definitions for the Text(D)Encoder interfaces added in GJS 1.69.2:
https://gitlab.gnome.org/GNOME/gjs/-/blob/572f8e8c/NEWS#L384-393
https://gitlab.gnome.org/GNOME/gjs/-/blob/master/doc/Encoding.md
https://gitlab.gnome.org/GNOME/gjs/-/blob/master/modules/esm/_encoding/encoding.js

