### PR TITLE
Enhance Glib.Error type with GJS specific additions

### DIFF
--- a/packages/cli/src/gir-factory.ts
+++ b/packages/cli/src/gir-factory.ts
@@ -196,6 +196,17 @@ export class GirFactory {
         }
     }
 
+    newGirProperties(
+        InjectionProps: InjectionProperty[],
+        overrideToAll: Partial<InjectionProperty> = {},
+    ): GirPropertyElement[] {
+        const result: GirPropertyElement[] = []
+        for (const InjectionProp of InjectionProps) {
+            result.push(this.newGirProperty({ ...InjectionProp, ...overrideToAll }))
+        }
+        return result
+    }
+
     newTsFunction(tsData: InjectionFunction, parent: TsClass | null): TsFunction {
         const tsFunc: TsFunction & TsMethod = {
             ...tsData,

--- a/packages/cli/src/injection/classes/gjs/GLib-2.0.ts
+++ b/packages/cli/src/injection/classes/gjs/GLib-2.0.ts
@@ -88,4 +88,114 @@ export const classesGLib20Gjs: InjectionClass[] = [
             },
         ],
     },
+    {
+        versions: ['2.0'],
+        qualifiedName: 'GLib.Error',
+        properties: [
+            // https://gitlab.gnome.org/GNOME/gjs/-/blob/d1cf26179322b2b87fb980e3b244b5e24dba8dd6/gi/gerror.cpp#L298-305
+            {
+                name: 'stack',
+                type: [{ type: 'string' }],
+                girTypeName: 'property',
+                doc: {
+                    text: 'The stack trace of the error.',
+                    tags: [
+                        {
+                            tagName: '@field',
+                            paramName: '',
+                            text: '',
+                        },
+                    ],
+                },
+            },
+            {
+                name: 'source',
+                type: [{ type: 'string' }],
+                girTypeName: 'property',
+                doc: {
+                    text: 'The name of the file where is the source of the error.',
+                    tags: [
+                        {
+                            tagName: '@field',
+                            paramName: '',
+                            text: '',
+                        },
+                    ],
+                },
+            },
+            {
+                name: 'line',
+                type: [{ type: 'number' }],
+                girTypeName: 'property',
+                doc: {
+                    text: 'The line number of the source of the error.',
+                    tags: [
+                        {
+                            tagName: '@field',
+                            paramName: '',
+                            text: '',
+                        },
+                    ],
+                },
+            },
+            {
+                name: 'column',
+                type: [{ type: 'number' }],
+                girTypeName: 'property',
+                doc: {
+                    text: 'The column number of the source of the error.',
+                    tags: [
+                        {
+                            tagName: '@field',
+                            paramName: '',
+                            text: '',
+                        },
+                    ],
+                },
+            },
+        ],
+        methods: [
+            // https://gitlab.gnome.org/GNOME/gjs/-/blob/33d58646d43b84d4c0ffc3681b89d125d5ccdfc6/installed-tests/js/testExceptions.js#L119-123
+            // https://gjs-docs.gnome.org/glib20~2.66.1/glib.error#constructor-new_literal
+            {
+                name: 'constructor',
+                isStatic: true,
+                returnTypes: [{ type: 'GLib.Error' }],
+                inParams: [
+                    {
+                        name: 'domain',
+                        type: [{ type: 'GLib.Quark' }],
+                    },
+                    {
+                        name: 'code',
+                        type: [{ type: 'number' }],
+                    },
+                    {
+                        name: 'message',
+                        type: [{ type: 'string' }],
+                    },
+                ],
+                girTypeName: 'constructor',
+            },
+            {
+                name: 'new',
+                returnTypes: [{ type: 'GLib.Error' }],
+                inParams: [
+                    {
+                        name: 'domain',
+                        type: [{ type: 'GLib.Quark' }],
+                    },
+                    {
+                        name: 'code',
+                        type: [{ type: 'number' }],
+                    },
+                    {
+                        name: 'message',
+                        type: [{ type: 'string' }],
+                    },
+                ],
+                girTypeName: 'constructor',
+            },
+        ],
+    },
 ]

--- a/packages/cli/src/injection/injector.ts
+++ b/packages/cli/src/injection/injector.ts
@@ -45,6 +45,11 @@ export class Injector {
                     ...this.girFactory.newGirFunctions(toClass.staticFunctions, girClass._tsData, { isInjected: true }),
                 )
             }
+            if (toClass.properties) {
+                girClass._tsData.properties.push(
+                    ...this.girFactory.newGirProperties(toClass.properties, { isInjected: true }),
+                )
+            }
             if (toClass.constructors) {
                 girClass._tsData.constructors.push(
                     ...this.girFactory.newGirFunctions(toClass.constructors, girClass._tsData, { isInjected: true }),

--- a/packages/cli/src/types/injection-class.ts
+++ b/packages/cli/src/types/injection-class.ts
@@ -1,4 +1,4 @@
-import type { InjectionFunction, InjectionGenericParameter, TsMethod } from './index.js'
+import type { InjectionFunction, InjectionGenericParameter, InjectionProperty, TsMethod } from './index.js'
 
 /** Interface to inject additional methods, properties, etc to a class */
 export interface InjectionClass {
@@ -10,7 +10,7 @@ export interface InjectionClass {
     /** Fields of the base class itself */
     // TODO: fields: InjectionField[]
     /** Properties of the base class itself */
-    // TODO: properties: InjectionProperty[]
+    properties?: InjectionProperty[]
     /** Constructor properties of the base class itself */
     // TODO:constructProps: InjectionProperty[]
     /** Array of signal methods for GObject properties */


### PR DESCRIPTION
Hello,

In GJS, `Glib.Error` is extended to have better interoperability with JS `Error`. This PR implements these GJS specific additions as injections. Basically, `Glib.Error`'s constructor becomes a proxy for `Glib.Error.new_literal` and the `stack`, `source`, `line` and `column` properties are added to it.

Sources:
https://gjs-docs.gnome.org/glib20~2.66.1/glib.error#constructor-new_literal
https://gitlab.gnome.org/GNOME/gjs/-/blob/33d58646d43b84d4c0ffc3681b89d125d5ccdfc6/installed-tests/js/testExceptions.js#L119-123
https://gitlab.gnome.org/GNOME/gjs/-/blob/d1cf26179322b2b87fb980e3b244b5e24dba8dd6/gi/gerror.cpp#L298-305