### PR TITLE
Fix `Gio.Cancellable.connect` method signature

### DIFF
--- a/packages/cli/src/gir-factory.ts
+++ b/packages/cli/src/gir-factory.ts
@@ -207,7 +207,7 @@ export class GirFactory {
             isInjected: tsData.isInjected || false,
             retTypeIsVoid: tsData.returnTypes?.length === 1 && tsData.returnTypes[0]?.type === 'void',
             generics: this.newGenerics(tsData.generics || []),
-            overloads: tsData.overloads || [],
+            overloads: (tsData.overloads || []).map((overload) => this.newTsFunction(overload, parent)),
             doc: this.newTsDoc(tsData.doc),
             tsTypeName: this.girTypeNameToTsTypeName(tsData.girTypeName, tsData.isStatic || false),
             inParams: [],

--- a/packages/cli/src/injection/classes/gjs/Gio-2.0.ts
+++ b/packages/cli/src/injection/classes/gjs/Gio-2.0.ts
@@ -216,4 +216,17 @@ export const classesGio20Gjs: InjectionClass[] = [
             },
         ],
     },
+    {
+        versions: ['2.0'],
+        qualifiedName: 'Gio.Cancellable',
+        methods: [
+            {
+                // https://gjs-docs.gnome.org/gio20~2.66p/gio.cancellable#method-connect
+                name: 'connect',
+                girTypeName: 'method',
+                returnTypes: [{ type: 'void' }],
+                inParams: [],
+            },
+        ],
+    },
 ]

--- a/packages/cli/src/injection/classes/gjs/Gio-2.0.ts
+++ b/packages/cli/src/injection/classes/gjs/Gio-2.0.ts
@@ -219,13 +219,35 @@ export const classesGio20Gjs: InjectionClass[] = [
     {
         versions: ['2.0'],
         qualifiedName: 'Gio.Cancellable',
-        methods: [
+        propertySignalMethods: [
             {
-                // https://gjs-docs.gnome.org/gio20~2.66p/gio.cancellable#method-connect
                 name: 'connect',
-                girTypeName: 'method',
-                returnTypes: [{ type: 'void' }],
-                inParams: [],
+                girTypeName: 'function',
+                returnTypes: [{ type: 'number' }],
+                inParams: [
+                    {
+                        name: 'sigName',
+                        type: [{ type: 'string' }],
+                    },
+                    {
+                        name: 'callback',
+                        type: [{ type: '(...args: any[]) => void' }],
+                    },
+                ],
+                overloads: [
+                    {
+                        // https://gjs-docs.gnome.org/gio20~2.66p/gio.cancellable#method-connect
+                        name: 'connect',
+                        girTypeName: 'function',
+                        returnTypes: [{ type: 'number' }],
+                        inParams: [
+                            {
+                                name: 'callback',
+                                type: [{ type: 'GObject.Callback' }],
+                            },
+                        ],
+                    },
+                ],
             },
         ],
     },

--- a/packages/cli/src/injection/injector.ts
+++ b/packages/cli/src/injection/injector.ts
@@ -63,7 +63,9 @@ export class Injector {
             if (toClass.propertySignalMethods) {
                 for (const propertySignalMethod of toClass.propertySignalMethods) {
                     propertySignalMethod.isInjected = true
-                    girClass._tsData.propertySignalMethods.push(propertySignalMethod)
+                    girClass._tsData.propertySignalMethods.push(
+                        this.girFactory.newTsFunction(propertySignalMethod, girClass._tsData),
+                    )
                 }
             }
 

--- a/packages/cli/src/type-definition-generator.ts
+++ b/packages/cli/src/type-definition-generator.ts
@@ -544,7 +544,7 @@ export default class TypeDefinitionGenerator implements Generator {
         const genericStr = this.generateGenericParameters(tsFunction.generics)
 
         // temporary solution, will be solved differently later
-        const commentOut = tsFunction.hasUnresolvedConflict ? '// Has conflict: ' : ''
+        const commentOut = tsFunction.hasUnresolvedConflict && !tsFunction.isInjected ? '// Has conflict: ' : ''
 
         let exportStr = ''
         // `tsType === 'function'` are a global methods which can be exported

--- a/packages/cli/src/types/injection-class.ts
+++ b/packages/cli/src/types/injection-class.ts
@@ -1,4 +1,4 @@
-import type { InjectionFunction, InjectionGenericParameter, TsMethod } from './index.js'
+import type { InjectionFunction, InjectionGenericParameter } from './index.js'
 
 /** Interface to inject additional methods, properties, etc to a class */
 export interface InjectionClass {
@@ -14,7 +14,7 @@ export interface InjectionClass {
     /** Constructor properties of the base class itself */
     // TODO:constructProps: InjectionProperty[]
     /** Array of signal methods for GObject properties */
-    propertySignalMethods?: TsMethod[]
+    propertySignalMethods?: InjectionFunction[]
     /** Methods of the base class itself */
     methods?: InjectionFunction[]
     /** Virtual methods of the base class itself */

--- a/packages/cli/src/types/injection-function.ts
+++ b/packages/cli/src/types/injection-function.ts
@@ -5,17 +5,10 @@ export interface InjectionFunction
         Partial<
             Pick<
                 TsFunction,
-                | 'isArrowType'
-                | 'isStatic'
-                | 'isGlobal'
-                | 'isVirtual'
-                | 'isInjected'
-                | 'overloads'
-                | 'generics'
-                | 'doc'
-                | 'parent'
+                'isArrowType' | 'isStatic' | 'isGlobal' | 'isVirtual' | 'isInjected' | 'generics' | 'doc' | 'parent'
             >
         > {
+    overloads?: InjectionFunction[]
     returnTypes?: InjectionType[]
     inParams?: InjectionParameter[]
     outParams?: InjectionParameter[]


### PR DESCRIPTION
Workaround for #87 

`Gio.Cancellable` extends  `GObject.Object`. However, `Gio.Cancellable.connect` method doesn't follow the `GObject.Object.connect` signature: 
https://gjs-docs.gnome.org/gio20~2.66p/gio.cancellable#method-connect

This PR implements the correct signature for the `connect` method as an overload in `Gio.Cancellable` class. This is not completely correct as it still considers the `GObject.Object.connect` signature valid, even tough it throws in runtime. However, it was the only non hacky solution that I could come up with due to how strict Typescript is with inheritance rules.

Beside this change, this PR also implements an exception during conflict resolution for injected methods and improve some of the injected types to be more lax and accept `InjectionFunction` in more places