### PR TITLE
Change Class Signal conflict resolution logic

### DIFF
--- a/packages/cli/src/conflict-resolver.ts
+++ b/packages/cli/src/conflict-resolver.ts
@@ -1007,7 +1007,7 @@ export class ConflictResolver {
                     // Function vs. Signal
                     else if (this.tsElementIsSignal(b.data)) {
                         this.log.debug(`${className}.${name} Direct Function vs. Signal`)
-                        baseFunc.hasUnresolvedConflict = true
+                        // Do nothing
                     }
                 }
 
@@ -1061,7 +1061,12 @@ export class ConflictResolver {
                     // Signal vs. Function
                     if (this.tsElementIsMethodOrFunction(b.data)) {
                         this.log.debug(`${className}.${name} Direct Signal vs. Function`)
-                        b.data.hasUnresolvedConflict = true
+                        const bFunc = b.data as TsFunction
+                        const baseSignal = base.data as TsFunction
+                        // Add parent class incompatible method as overload
+                        if (!this.getCompatibleTsFunction(baseSignal.overloads, bFunc)) {
+                            baseSignal.overloads.push(bFunc)
+                        }
                     }
                 }
                 // If a element is a constructor


### PR DESCRIPTION
Hello,

This is a better solution for #87.

It changes the conflict resolution logic for classes signals. Now it accepts methods as overloads for parent signals, and pull incompatible parent methods as overloads for signals. As far as I could test, this allows for classes that implement `methods` with incompatible signature to `propertySignalMethods` be properly typed. However, with the caveat that classes that completely override the parent implementation (such as `Gio.Cancellable.connect`) will still be typed as accepting it, even tough that is not true on runtime. I am thinking on a solution for this, but it will probably require some runtime monkey-patching, so I don't know if it will be viable. For now, I think this is a good approach to solve the original issue tough.